### PR TITLE
Fix superscripts.

### DIFF
--- a/ox-rst.el
+++ b/ox-rst.el
@@ -1329,8 +1329,8 @@ contextual information."
 CONTENTS is the contents of the object.  INFO is a plist holding
 contextual information."
   (if (org-element-property :use-brackets-p superscript)
-      (format "_{%s}" contents)
-    (format "_%s" contents)))
+      (format "^{%s}" contents)
+    (format "^%s" contents)))
 
 
 ;;;; Table


### PR DESCRIPTION
Superscripts were being converted to subscripts beforehand. Err, this is a two character change, haha.

Thanks for your work on this excellent exporter. I can think of other software where this would take much longer to track down.

New behavior can be seen here:

http://johnwalker.github.io/posts/Legendre-Symbol.html
