### PR TITLE
Added empty line after rst figure command, changed org-ascii--justify-(string) to (lines)

### DIFF
--- a/ox-rst.el
+++ b/ox-rst.el
@@ -1079,7 +1079,7 @@ INFO is a plist holding contextual information."
 					 (expand-file-name raw-path)))
 			(caption (org-export-get-caption
 					  (org-export-get-parent-element link))))
-		(if caption (format ".. figure:: %s%s\n    %s\n" ipath attributes
+		(if caption (format ".. figure:: %s%s\n \n   %s\n" ipath attributes
 							(org-export-data caption info))
 		  (format ".. image:: %s%s\n" ipath	attributes))))
      ((and (plist-get info :rst-inline-images)
@@ -1500,7 +1500,7 @@ a communication channel."
     (let* ((indent-tabs-mode nil)
 	   (data
 	    (when contents
-	      (org-ascii--justify-string
+	      (org-ascii--justify-lines
 	       contents width
 	       (org-export-table-cell-alignment table-cell info)))))
       (setq contents (concat data


### PR DESCRIPTION
1.  I think there was a bug for figures, you need an empty line after

.. figure:: image.jpg

before you place the caption text.

2.  I pulled the latest org-mode version from git.

org-ascii--justify-string

has been renamed to

org-ascii--justify-lines

Looks like the code is the same.

Git version I am using is shown below:

Commits in HEAD
* b4b6584eea27b5c1d25572ec957c49c77051ec72 HEAD origin/master origin/HEAD master
| Author: Kyle Meyer <kyle@kyleam.com>
| Date:   Fri Jan 2 17:38:30 2015 -0500
|
|     org-agenda-Quit: Remove unnecessary function calls
|
|     * lisp/org-agenda.el (org-agenda-Quit): Remove unnecessary function calls.
|
|     - org-agenda-Quit turns off column view if it is active, instead of
|       killing the agenda buffer, so there is no need to call
|       org-columns-remove-overlays when killing the buffer.
|     - org-agenda-reset-markers is already called when the kill-buffer-hook
|       is run.
|
|  lisp/org-agenda.el | 4 ----
|  1 file changed, 4 deletions(-)
|