### PR TITLE
No title if "title:nil" is set

### DIFF
--- a/ox-rst.el
+++ b/ox-rst.el
@@ -488,6 +488,7 @@ INFO is a plist used as a communication channel."
                        (concat subtitleline "\n"
                                subtitle "\n"
                                subtitleline "\n") "")))
+    (if with-title
 	(concat
 	 titleline "\n"
 	 title "\n"
@@ -496,7 +497,7 @@ INFO is a plist used as a communication channel."
 	 (when (org-string-nw-p author) (concat "\n    :Author: " author))
 	 (when (org-string-nw-p email) (concat "\n    :Contact: " email))
 	 (when (org-string-nw-p date) (concat "\n    :Date: " date))
-	 "\n")))
+	 "\n"))))
 
 
 (defun org-rst-template (contents info)


### PR DESCRIPTION
This adds a test of the `with-title` value before concatenating the title lines. This way, the defaults in the original still carry through if title export is left default (true), but nothing is printed if the user has explicitly set title export to nil.

This is my first Lisp programming ever, so please assume I made mistakes!