### PR TITLE
Add consideration for inline image in a paragraph.

### DIFF
--- a/ox-rst.el
+++ b/ox-rst.el
@@ -1085,11 +1085,12 @@ CONTENTS is the contents of the paragraph, as a string.  INFO is
 the plist used as a communication channel."
   (when (plist-get _info :preserve-breaks)
     (let ((lines (split-string contents "\n+[ \t\n]*")))
-      (cond ((> (length lines) 2)
-             (setq contents (apply 'concat (mapcar
-                                            '(lambda (x) (if (> (length x) 0) (concat "| " x "\n") x))
-                                            lines)))))))
-  contents)
+      (if (or (<= (length lines) 2)
+              (string-prefix-p ".." contents))
+          contents
+        (apply 'concat (mapcar
+                        (lambda (x) (if (> (length x) 0) (concat "| " x "\n") x))
+                        lines))))))
 
 
 ;;;; Plain List


### PR DESCRIPTION
The function "org-rst-paragraph" I modified was not considering a parameter value as directives.  
Therefore, when the content value was multi-line directive expression such as inline image with a caption,  
it treat content as a paragraph like below:  

    | .. figure:: /path/to/image.jpg
    | caption

So I added a conditional to avoid any directives to be treated as a paragraph.  
