### PR TITLE
The construct \d for any digit is not supported

### DIFF
--- a/ox-rst.el
+++ b/ox-rst.el
@@ -1085,7 +1085,7 @@ contextual information."
   ;; Protect ..
   (setq text (replace-regexp-in-string "^[\s-]*\\.\\. [^\\[]" "\\\\.. " text))
   ;; Protect ^\d+.
-  (setq text (replace-regexp-in-string "^\\(\\d\\)+\\." "\\1\\." text))
+  (setq text (replace-regexp-in-string "^\\([[:digit:]]\\)+\\." "\\1\\." text))
   ;; Return value.
   text)
 


### PR DESCRIPTION
The construct \d for any digit is not supported, use [0-9] or [:digit:] instead

https://www.emacswiki.org/emacs/RegularExpression